### PR TITLE
fix build: add cmake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,62 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(seg_label_generate)
+
+set(CMAKE_CXX_STANDARD 11)
+
+add_definitions(
+    -DCPU_ONLY
+)
+
+set(EXECUTE_COMMAND find src/ -name "*.cpp")
+
+execute_process(
+    COMMAND ${EXECUTE_COMMAND}
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE CXX_SRCS_RAW
+)
+string(REPLACE "\n" ";" CXX_SRCS ${CXX_SRCS_RAW}) # drop blank line
+
+add_executable(${PROJECT_NAME}
+    ${CXX_SRCS}
+)
+
+set(dep_libs "")
+
+#--- OpenCV
+# You may switch different version of OpenCV like this:
+# set(OpenCV_DIR "/usr/local/opencv-4.3.0" CACHE PATH "")
+find_package(OpenCV REQUIRED 
+    COMPONENTS core highgui imgproc imgcodecs
+)
+if(NOT OpenCV_FOUND) # if not OpenCV 4.x/3.x, then imgcodecs are not found
+    find_package(OpenCV REQUIRED COMPONENTS core highgui imgproc)
+endif()
+
+list(APPEND dep_libs 
+    PUBLIC ${OpenCV_LIBS}
+)
+
+#--- OpenMP
+find_package(OpenMP)
+if(NOT TARGET OpenMP::OpenMP_CXX AND (OpenMP_CXX_FOUND OR OPENMP_FOUND))
+    target_compile_options(${PROJECT_NAME} PRIVATE ${OpenMP_CXX_FLAGS})
+endif()
+
+if(OpenMP_CXX_FOUND OR OPENMP_FOUND)
+    message(STATUS "Building with OpenMP")
+    if(OpenMP_CXX_FOUND)
+        list(APPEND dep_libs PUBLIC OpenMP::OpenMP_CXX)
+    else()
+        list(APPEND dep_libs PRIVATE "${OpenMP_CXX_FLAGS}")
+    endif()
+endif()
+
+# --- target config with include dirs / libs
+target_link_libraries(${PROJECT_NAME}
+    ${dep_libs}
+)
+
+target_include_directories(${PROJECT_NAME}
+    PUBLIC include
+)

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ COMMON_FLAGS := -DCPU_ONLY
 CXXFLAGS := -std=c++11 -fopenmp
 LDFLAGS := -fopenmp -Wl,-rpath,./lib
 
+# You may switch different versions of opencv like this:
+# export PKG_CONFIG_PATH=/usr/local/opencv-4.1.1/lib/pkgconfig:$PKG_CONFIG_PATH 
+# then use `pkg-config opencv4 --cflags --libs` since `opencv4.pc` is found
 OPENCV = `pkg-config opencv --cflags --libs`
 LIB = $(OPENCV)
 BUILD_DIR := build

--- a/README.md
+++ b/README.md
@@ -11,11 +11,17 @@ It could:
 
 Note: If you have downloaded the dataset before 16th April 2018, please update the raw annotations for train&val set as described in the dataset website.
 
-2. Clone and make
+2. Clone and build
     ```Shell
     git clone https://github.com/XingangPan/seg_label_generate.git
     cd seg_label_generate
+    
+    # if you prefer makefile
     make
+    
+    # or, if you prefer cmake
+    mkdir build && cd build
+    cmake ..
     ```
 
 ### Run the code


### PR DESCRIPTION
Hi, Xingang

CMake is widely used for C/C++ projects, and I add cmake support according to existing Makefile. Build OK on my ubuntu16.04.
Hope this will help since I see other open source projects (e.g. https://github.com/cfzd/Ultra-Fast-Lane-Detection) are using this.